### PR TITLE
[feature][cuda] add kernel_type argument to the CudaArgs

### DIFF
--- a/cmake/deps.cmake
+++ b/cmake/deps.cmake
@@ -269,7 +269,8 @@ endif()
 
 if(PPLNN_USE_CUDA)
     if(NOT PPLNN_DEP_PPLCUDAKERNEL_VERSION)
-        set(PPLNN_DEP_PPLCUDAKERNEL_VERSION master)
+        # set(PPLNN_DEP_PPLCUDAKERNEL_VERSION master)
+        set(PPLNN_DEP_PPLCUDAKERNEL_VERSION cutlass_conv)
     endif()
 
     if(PPLNN_DEP_PPLCUDAKERNEL_PKG)
@@ -277,7 +278,8 @@ if(PPLNN_USE_CUDA)
             ${PPLNN_DEP_PPLCUDAKERNEL_PKG})
     else()
         if(NOT PPLNN_DEP_PPLCUDAKERNEL_GIT)
-            set(PPLNN_DEP_PPLCUDAKERNEL_GIT "https://github.com/openppl-public/ppl.kernel.cuda.git")
+            # set(PPLNN_DEP_PPLCUDAKERNEL_GIT "https://github.com/openppl-public/ppl.kernel.cuda.git")
+            set(PPLNN_DEP_PPLCUDAKERNEL_GIT "https://github.com/xiyanjoy/ppl.kernel.cuda.git")
         endif()
         hpcc_declare_git_dep(ppl.kernel.cuda
             ${PPLNN_DEP_PPLCUDAKERNEL_GIT}

--- a/src/ppl/nn/engines/cuda/engine.cc
+++ b/src/ppl/nn/engines/cuda/engine.cc
@@ -153,6 +153,7 @@ static void ExportAlgorithmsInfo(const map<string, CudaArgs::AlgoSelects>& algos
     for (auto s = algos.begin(); s != algos.end(); ++s) {
         auto& item = s->second;
         rapidjson::Value object(rapidjson::kObjectType);
+        object.AddMember("ktype", rapidjson::StringRef(item.ktype.data(), item.ktype.size()), allocator);
         object.AddMember("kname", rapidjson::StringRef(item.kname.data(), item.kname.size()), allocator);
         object.AddMember("kid", item.kid, allocator);
         object.AddMember("splitk", item.splitk, allocator);
@@ -491,6 +492,10 @@ static RetCode ImportAlgorithmsImpl(const char* json_buffer, uint64_t buffer_siz
         ref = it->value.FindMember("splitf");
         if (ref != it->value.MemberEnd()) {
             algo_info.splitf = ref->value.GetInt();
+        }
+        ref = it->value.FindMember("ktype");
+        if (ref != it->value.MemberEnd()) {
+            algo_info.ktype.assign(ref->value.GetString(), ref->value.GetStringLength());
         }
         ref = it->value.FindMember("kname");
         if (ref != it->value.MemberEnd()) {

--- a/src/ppl/nn/engines/cuda/engine.h
+++ b/src/ppl/nn/engines/cuda/engine.h
@@ -41,6 +41,7 @@ typedef std::set<nodeid_t> CompileInfo;
 
 struct CudaArgs {
     struct AlgoSelects {
+        std::string ktype;
         std::string kname;
         int kid = 0;
         int splitk = 1;

--- a/src/ppl/nn/engines/cuda/optimizer/ops/onnx/conv_op.cc
+++ b/src/ppl/nn/engines/cuda/optimizer/ops/onnx/conv_op.cc
@@ -138,7 +138,8 @@ RetCode ConvOp::Finalize(const OptKernelOptions& options) {
 KernelImpl* ConvOp::CreateKernelImpl() const {
     if (param_.extra_param.algo_info.algo_type == "TuringHMMAImpgemm") {
         return CreateKernelImplWithParam<ConvHmmaKernel>(&param_);
-    } else if (param_.extra_param.algo_info.algo_type == "TuringIMMAImpgemm") {
+    } else if (param_.extra_param.algo_info.algo_type == "TuringIMMAImpgemm" || \
+    param_.extra_param.algo_info.algo_type == "CutlassHConv") {
         return CreateKernelImplWithParam<ConvImmaKernel>(&param_);
     } else if (param_.extra_param.algo_info.algo_type == "DepthwiseDirect") {
         return CreateKernelImplWithParam<ConvDepthwiseKernel>(&param_);


### PR DESCRIPTION
Consider the requirement of adding more kernel to one algo(for example, add the cutlass conv choice to TuringHMMAImpgemm algo), add kernel_type argument to the CudaArgs at first.