### PR TITLE
[fix] change conv default algo and set with corresponding correct index

### DIFF
--- a/src/ppl/nn/engines/cuda/optimizer/algos/algo_conv_hmma.cc
+++ b/src/ppl/nn/engines/cuda/optimizer/algos/algo_conv_hmma.cc
@@ -80,8 +80,8 @@ double TuringHMMAImpgemm::ExcuteTimer(const ir::Node* node, OptKernelOptions& op
         return 0.0f;
     } else { // Give the default kernel
 #ifdef PPLNN_CUDA_ENABLE_KERNEL_CUT
-        attr_param_.extra_param.algo_info.algo_name = "nvSwzlSm75Fp16Conv_hmma1688_nhwc_fn_b32x256_w32x64_k8_buf2";
-        attr_param_.extra_param.algo_info.kid = 685;
+        attr_param_.extra_param.algo_info.algo_name = "nvSwzlSm75Fp16Conv_hmma1688_nhwc_fn_b32x256_w32x64_k8_buf1";
+        attr_param_.extra_param.algo_info.kid = 622;
 #else
         attr_param_.extra_param.algo_info.algo_name = "nvSwzlSm75Fp16Conv_hmma1688_nhwc_fn_b128x64_w64x32_k64_buf2";
         attr_param_.extra_param.algo_info.kid = 5197;


### PR DESCRIPTION
The default conv algo index does not correspond to the one in the conv algo table. This PR just change default algo and set correct index.